### PR TITLE
Move core logic to BikeComputer class, calculate & display distance

### DIFF
--- a/firmware/src/bike_computer.cpp
+++ b/firmware/src/bike_computer.cpp
@@ -1,6 +1,3 @@
-//
-// Created by Suyash Kumar on 2/1/20.
-//
 #include "Arduino.h"
 #include "bike_computer.h"
 

--- a/firmware/src/bike_computer.cpp
+++ b/firmware/src/bike_computer.cpp
@@ -1,0 +1,60 @@
+//
+// Created by Suyash Kumar on 2/1/20.
+//
+#include "Arduino.h"
+#include "bike_computer.h"
+
+#define THRESHOLD 300
+#define VERIFY_ITER_N 10
+#define SCREEN_WIDTH 128 // OLED display width, in pixels
+#define SCREEN_HEIGHT 32 // OLED display height, in pixels
+#define PI 3.14159265
+#define BIKE_RADIUS 0.20 // in m
+
+void BikeComputer::Init() {
+    pinMode(A0, INPUT);
+    Serial.begin(9600);
+    display.Init();
+    delay(500);
+}
+
+void BikeComputer::HandleLoop() {
+    if (UpdateTriggerState()) {
+        distance = 2 * PI * BIKE_RADIUS * num_revolutions; // in m
+        display.RevsAndDistance(num_revolutions, distance);
+    }
+}
+
+bool BikeComputer::UpdateTriggerState() {
+    // TODO: count and timestamp detected unique revolutions.
+    if (IsSwitchTriggered() && !prev_trigger_state) {
+        // New unique revolution
+        prev_trigger_state = true;
+        num_revolutions += 1;
+        return true;
+
+    } else if (!IsSwitchTriggered() && prev_trigger_state) {
+        // Switch is not triggered anymore, update previous trigger state
+        prev_trigger_state = false;
+    }
+
+    delay(10);
+    return false;
+}
+
+bool BikeComputer::IsSwitchTriggered() {
+        // TODO: can probably use digitalRead instead of analogRead and threshold
+        if (analogRead(A0) < THRESHOLD) {
+            // Do a couple more reads to verify that we should really count this as a trigger
+            int summed_values = 0;
+            for (int i = 0; i < VERIFY_ITER_N; i++) {
+                summed_values += analogRead(A0);
+                delay(4);
+            }
+            if (summed_values < (THRESHOLD * VERIFY_ITER_N)) {
+                return true;
+            }
+        }
+
+        return false;
+}

--- a/firmware/src/bike_computer.h
+++ b/firmware/src/bike_computer.h
@@ -1,0 +1,22 @@
+#ifndef FIRMWARE_BIKE_COMPUTER_H
+#define FIRMWARE_BIKE_COMPUTER_H
+#include "display.h"
+
+class BikeComputer {
+public:
+    BikeComputer(): display(), prev_trigger_state(false), num_revolutions(0) {};
+
+    void Init();
+    void HandleLoop();
+
+private:
+    bool IsSwitchTriggered();
+    bool UpdateTriggerState();
+
+    BikeDisplay display;
+    bool prev_trigger_state;
+    int num_revolutions;
+    double distance;
+};
+
+#endif //FIRMWARE_BIKE_COMPUTER_H

--- a/firmware/src/display.cpp
+++ b/firmware/src/display.cpp
@@ -46,10 +46,6 @@ void BikeDisplay::PrepareDisplayForPrint(bool is_center_cursor) {
     }
 }
 
-void BikeDisplay::Distance(const float &dist) {
-
-}
-
 void BikeDisplay::RevsAndDistance(const int& revs, const double& dist) {
     PrepareDisplayForPrint();
     display.print(F("Revs: "));

--- a/firmware/src/display.cpp
+++ b/firmware/src/display.cpp
@@ -21,11 +21,12 @@ void BikeDisplay::Init() {
         exit(1);  // TODO: figure out if this error happens often, and if so, how best to handle
     }
     PrepareDisplayForPrint(/*is_center_cursor=*/true);
-    display.print(F("Bike!"));
+    display.println(F("Bike Time!"));
     display.display();
+    delay(1000);
 }
 
-void BikeDisplay::UpdateRevs(const int& revs) {
+void BikeDisplay::Revolutions(const int& revs) {
     PrepareDisplayForPrint(/*is_center_cursor=*/true);
     display.print(F("Revs: "));
     display.print(revs);
@@ -43,4 +44,24 @@ void BikeDisplay::PrepareDisplayForPrint(bool is_center_cursor) {
     } else {
         display.setCursor(0, 0);
     }
+}
+
+void BikeDisplay::Distance(const float &dist) {
+
+}
+
+void BikeDisplay::RevsAndDistance(const int& revs, const double& dist) {
+    PrepareDisplayForPrint();
+    display.print(F("Revs: "));
+    display.print(revs);
+
+    display.println();
+
+    display.print(F("Dist: "));
+    char buffer[5];
+    sprintf(buffer, "%4f", dist);
+    display.print(buffer);
+
+    display.display();
+
 }

--- a/firmware/src/display.h
+++ b/firmware/src/display.h
@@ -8,7 +8,6 @@ public:
 
     void Init();
     void Revolutions(const int& revs);
-    void Distance(const float& dist);
     void RevsAndDistance(const int& revs, const double& dist);
 
 private:

--- a/firmware/src/display.h
+++ b/firmware/src/display.h
@@ -7,7 +7,9 @@ public:
     BikeDisplay();
 
     void Init();
-    void UpdateRevs(const int& revs);
+    void Revolutions(const int& revs);
+    void Distance(const float& dist);
+    void RevsAndDistance(const int& revs, const double& dist);
 
 private:
     void PrepareDisplayForPrint(bool is_center_cursor=false);

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -4,54 +4,14 @@
  * @author Suyash Kumar <suyash@suyashkumar.com>
  */
 #include "Arduino.h"
-#include "display.h"
+#include "bike_computer.h"
 
-#define THRESHOLD 300 
-#define VERIFY_ITER_N 10
-#define SCREEN_WIDTH 128 // OLED display width, in pixels
-#define SCREEN_HEIGHT 32 // OLED display height, in pixels
-
-bool previous_trigger_state = false;
-int num_revolutions = 0;
-BikeDisplay display;
+BikeComputer bike_computer;
 
 void setup() {
-  pinMode(LED_BUILTIN, OUTPUT);
-  pinMode(A0, INPUT);
-  Serial.begin(9600);
-  display.Init();
-  delay(2000);
-}
-
-bool switch_is_triggered() {
-  // TODO: can probably use digitalRead instead of analogRead and threshold
-  if (analogRead(A0) < THRESHOLD) {
-  	// Do a couple more reads to verify that we should really count this as a trigger
-  	int summed_values = 0;
-    for (int i = 0; i < VERIFY_ITER_N; i++) {
-	  summed_values += analogRead(A0);
-	  delay(4);
-	}
-	if (summed_values < (THRESHOLD * VERIFY_ITER_N)) {
-	  return true;
-	}
-  }
-
-  return false;
+    bike_computer.Init();
 }
 
 void loop() {
-  // TODO: count and timestamp detected unique revolutions.
-  if (switch_is_triggered() && !previous_trigger_state) { 
-    // New unique revolution
-    previous_trigger_state = true;
-	num_revolutions += 1;
-	display.UpdateRevs(num_revolutions);
-
-  } else if (!switch_is_triggered() && previous_trigger_state) {
-    // Switch is not triggered anymore, update previous trigger state
-	previous_trigger_state = false;
-  }
-
-  delay(10);
+    bike_computer.HandleLoop();
 }


### PR DESCRIPTION
This change factors out the core firmware logic to the `BikeComputer` class, in addition to calculating and displaying distance traveled. 

![IMG_7479](https://user-images.githubusercontent.com/6299853/73603821-80d4b780-453c-11ea-8677-6397263b703e.gif)
